### PR TITLE
Add globals support

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,12 +42,12 @@ module.exports = function(apps, config) {
         });
     }
 
-  const globals = config.globals;
-  if (globals) {
-    Object.keys(globals).forEach(name => {
-      env.addGlobal(name, globals[name]);
-    });
-  }
+    const globals = config.globals;
+    if (globals) {
+        Object.keys(globals).forEach(name => {
+            env.addGlobal(name, globals[name]);
+        });
+    }
 
     const engine = function(filePath, ctx, cb) {
         const view = this;

--- a/index.js
+++ b/index.js
@@ -42,6 +42,13 @@ module.exports = function(apps, config) {
         });
     }
 
+  const globals = config.globals;
+  if (globals) {
+    Object.keys(globals).forEach(name => {
+      env.addGlobal(name, globals[name]);
+    });
+  }
+
     const engine = function(filePath, ctx, cb) {
         const view = this;
         const name = path.extname(view.name) ? view.name : view.name + view.ext;

--- a/test/templates/globals.html
+++ b/test/templates/globals.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{snake(title)}}</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/test/test.js
+++ b/test/test.js
@@ -52,6 +52,33 @@ test('custom filters', async t => {
     t.regex(res.text, /SnAkE/);
 });
 
+test('custom globals', async t => {
+  const app = express();
+  app.set('views', __dirname + '/templates');
+
+  const globals = {
+    snake: function(text) {
+      return (text || '').split('').map(function(ch, i) {
+        return i % 2 === 0 ? ch.toUpperCase() : ch.toLowerCase();
+      }).join('');
+    }
+  };
+
+  const njk = expressNunjucks(app, {
+    globals: globals
+  });
+
+  app.get('/', (req, res) => {
+    res.render('globals', {title: 'snake'});
+  });
+
+  const res = await request(app)
+    .get('/')
+    .expect(200);
+
+  t.regex(res.text, /SnAkE/);
+});
+
 
 test('custom tags', async t => {
     const app = express();

--- a/test/test.js
+++ b/test/test.js
@@ -53,30 +53,30 @@ test('custom filters', async t => {
 });
 
 test('custom globals', async t => {
-  const app = express();
-  app.set('views', __dirname + '/templates');
+    const app = express();
+    app.set('views', __dirname + '/templates');
 
-  const globals = {
-    snake: function(text) {
-      return (text || '').split('').map(function(ch, i) {
-        return i % 2 === 0 ? ch.toUpperCase() : ch.toLowerCase();
-      }).join('');
-    }
-  };
+    const globals = {
+        snake: function(text) {
+            return (text || '').split('').map(function(ch, i) {
+                return i % 2 === 0 ? ch.toUpperCase() : ch.toLowerCase();
+            }).join('');
+        }
+    };
 
-  const njk = expressNunjucks(app, {
-    globals: globals
-  });
+    const njk = expressNunjucks(app, {
+        globals: globals
+    });
 
-  app.get('/', (req, res) => {
-    res.render('globals', {title: 'snake'});
-  });
+    app.get('/', (req, res) => {
+        res.render('globals', {title: 'snake'});
+    });
 
-  const res = await request(app)
-    .get('/')
-    .expect(200);
+    const res = await request(app)
+        .get('/')
+        .expect(200);
 
-  t.regex(res.text, /SnAkE/);
+    t.regex(res.text, /SnAkE/);
 });
 
 


### PR DESCRIPTION
This PR adds support for `globals`. It makes possible create variables and functions accessible in any template.

Instead writing *uggly* syntaxes like:

```
{{ 'styles.css'|asset }}
```

We can write:

```
{{ asset('styles.css') }}
```
What currently this library does not support.
The logic and tests are absolutely the same applied to `filters`.